### PR TITLE
fixed invalid facebook sharer exclude regex in .lycheeignore

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -20,7 +20,7 @@ https://www.amqp.org/
 
 # This can be ignored and excluded as it is in a template layout file... not a static external URL...
 # By the way, this layout has not been used on the website so far. We keep it as part of the template, just in case.
-https://facebook.com/sharer/sharer.php?u={{%20$url%20}}
+https://facebook\.com/sharer/sharer\.php\?u=.*
 
 # Add valid URLs here, when the broken link error is due to web site rate limit... 
 https://mvnrepository.com/repos/central


### PR DESCRIPTION
- Replaced literal Hugo template URL with a valid regex pattern
- Prevents Lychee regex parse errors when loading exclude rules
- Ensures the career layout Facebook share link is excluded from link checks